### PR TITLE
Add MIT license headers to all source files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 const nextJest = require('next/jest');
 
 const createJestConfig = nextJest({

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',

--- a/packages/spark-slider/src/index.ts
+++ b/packages/spark-slider/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 export { default as SparkSlider } from './spark/SparkSlider';
 export { useSparkSlider, computeSwipeTarget } from './spark/useSparkSlider';
 export { SLIDER_CONFIG } from './spark/config';

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 module.exports = {
   plugins: {
     tailwindcss: {},

--- a/src/app/about-sponsor/page.tsx
+++ b/src/app/about-sponsor/page.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import Link from 'next/link';
 
 export default function AboutSponsorPage() {

--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 'use client';
 
 import { SLIDER_CONFIG, SparkSlider } from '@ashbuk/spark-slider';

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 'use client';
 
 import { useEffect, useState } from 'react';

--- a/src/components/SparkSlider/SparkSlider.tsx
+++ b/src/components/SparkSlider/SparkSlider.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 'use client';
 /* eslint-disable @next/next/no-img-element */
 /**

--- a/src/components/SparkSlider/config.ts
+++ b/src/components/SparkSlider/config.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 export type CardPosition =
   | 'center'
   | 'left'

--- a/src/components/SparkSlider/useSparkSlider.ts
+++ b/src/components/SparkSlider/useSparkSlider.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 'use client';
 
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [

--- a/tests/setup/jest.setup.js
+++ b/tests/setup/jest.setup.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import '@testing-library/jest-dom';
 
 // Mock Framer Motion to avoid animation issues in tests

--- a/tests/setup/test-utils.tsx
+++ b/tests/setup/test-utils.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 

--- a/tests/unit/components/SparkSlider.test.tsx
+++ b/tests/unit/components/SparkSlider.test.tsx
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import React from 'react';
 import '@testing-library/jest-dom';
 import {

--- a/tests/unit/hooks/useSparkSlider.test.ts
+++ b/tests/unit/hooks/useSparkSlider.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import { renderHook, act } from '@testing-library/react';
 import { useSparkSlider } from '@ashbuk/spark-slider';
 

--- a/tests/unit/utils/computeSwipeTarget.test.ts
+++ b/tests/unit/utils/computeSwipeTarget.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2025 Asher Buk
+ * SPDX-License-Identifier: MIT
+ */
+
 import { computeSwipeTarget } from '@ashbuk/spark-slider';
 
 describe('computeSwipeTarget', () => {


### PR DESCRIPTION
Added copyright notice and SPDX license identifier to:
- Source files in src/ and packages/
- Configuration files (next.config.js, tailwind.config.js, etc.)
- Test files and utilities
- CSS files

This ensures proper attribution and license compliance across the codebase.